### PR TITLE
Add missing thread include

### DIFF
--- a/kuksa-cpp-client/src/kuksa_client.cpp
+++ b/kuksa-cpp-client/src/kuksa_client.cpp
@@ -22,6 +22,7 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 #include <vector>
+#include <thread>
 
 namespace kuksa {
 


### PR DESCRIPTION
This include is mising. That does not allow building on bookworm, it fails with

```
[ 85%] Building CXX object src/CMakeFiles/kuksaclient.dir/kuksa_client.cpp.o
/build/kuksa-incubation/kuksa-cpp-client/src/kuksa_client.cpp:418:8: error: 'thread' in namespace 'std' does not name a type
  418 |   std::thread mSubscribeThread;
      |        ^~~~~~
/build/kuksa-incubation/kuksa-cpp-client/src/kuksa_client.cpp:24:1: note: 'std::thread' is defined in header '<thread>'; did you forget to '#include <thread>'?
   23 | #include <spdlog/spdlog.h>
  +++ |+#include <thread>
   24 | #include <vector>
```

This fixes that