### PR TITLE
Fix nested Cmake build

### DIFF
--- a/kuksa-cpp-client/src/generate.cmake
+++ b/kuksa-cpp-client/src/generate.cmake
@@ -11,14 +11,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************/
 # Recursively find all .proto files
-file(GLOB_RECURSE proto_files "${CMAKE_SOURCE_DIR}/proto/*.proto")
+file(GLOB_RECURSE proto_files "${PROJECT_SOURCE_DIR}/proto/*.proto")
 
 add_library(proto-objects OBJECT ${PROTO_FILES})
 
 target_link_libraries(proto-objects PUBLIC protobuf::libprotobuf gRPC::grpc++)
 
 set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/proto")
-set(PROTO_IMPORT_DIRS "${CMAKE_SOURCE_DIR}/proto")
+set(PROTO_IMPORT_DIRS "${PROJECT_SOURCE_DIR}/proto")
 
 # Ensure the output directory exists
 file(MAKE_DIRECTORY ${PROTO_BINARY_DIR})


### PR DESCRIPTION
Backport (Forwardport) the fix from https://github.com/AkhilTThomas/kuksa-cpp-client/commit/0174ea16c764ccbfb427f99678b6827a6ffcfb5e

making sure the lib can also be build when the CMake is called from another cmake project.

