### PR TITLE
Enable CI build for kuksa_cpp_client

### DIFF
--- a/.github/workflows/kuksa_cpp_client.yaml
+++ b/.github/workflows/kuksa_cpp_client.yaml
@@ -1,0 +1,46 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: kuksa_cpp_client
+
+on:
+  push:
+  pull_request:
+    paths:
+      - ".github/workflows/kuksa_cpp_client.yaml"
+      - "kuksa_cpp_client/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+
+  kuksa-cpp-client-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout kuksa-incubation
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Just
+        uses: extractions/setup-just@v2
+      - name: Get Conan
+        uses: turtlebrowser/get-conan@v1.0
+      - name: Build kuksa_cpp_client
+        run: |
+          cd kuksa-cpp-client
+          just prepare
+          just configure
+          just build


### PR DESCRIPTION
Add `kuksa-cpp-client` to the CI pipeline.

Reference run: https://github.com/AkhilTThomas/kuksa-incubation/actions/runs/13656200084/job/38175867644

@SebastianSchildt 