### PR TITLE
zenoh-kuksa-provider uses kuksa-rust-sdk

### DIFF
--- a/zenoh-kuksa-provider/Cargo.toml
+++ b/zenoh-kuksa-provider/Cargo.toml
@@ -11,6 +11,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ########################################################################
 
+[workspace]
+
+
 [package]
 name = "zenoh-kuksa-provider"
 version = "0.1.0"
@@ -20,9 +23,11 @@ edition = "2021"
 clap = { version = "4.5.18", features = ["derive", "env"] }
 env_logger = "0.10.2"
 json5 = "0.4.1"
-kuksa = { git = "https://github.com/eclipse-kuksa/kuksa-databroker.git", branch = "feature/refactor_kuksa_crate", package = "kuksa" }
+kuksa-rust-sdk = "0.1.2"
 log = "0.4.21"
-prost-types = "0.11.9"
+prost-types = "0.12.4"
 serde = { version = "1.0.207", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
-zenoh = { version = "1.0.0" }
+zenoh = { version = "1.3.4" }
+# use same version of http as in kuksa-rust-sdk
+http = "0.2.12"

--- a/zenoh-kuksa-provider/Cargo.toml
+++ b/zenoh-kuksa-provider/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2021"
 clap = { version = "4.5.18", features = ["derive", "env"] }
 env_logger = "0.10.2"
 json5 = "0.4.1"
-kuksa-rust-sdk = "0.1.2"
+kuksa-rust-sdk = "0.1.3"
 log = "0.4.21"
 prost-types = "0.12.4"
 serde = { version = "1.0.207", features = ["derive"] }

--- a/zenoh-kuksa-provider/src/main.rs
+++ b/zenoh-kuksa-provider/src/main.rs
@@ -91,17 +91,16 @@ async fn publish_to_zenoh(
     session: Arc<Session>,
     mut kuksa_client: KuksaClient
 ) {
-    let vss_paths = Vec::from_iter(provider_config.signals.iter().map(String::as_str));
-
     let mut publishers: HashMap<String, Publisher<'_>> = HashMap::new();
     for vss_path in provider_config.signals.clone() {
         let zenoh_key = vss_path.replace(".", "/");
         let publisher = session.declare_publisher(zenoh_key.clone()).await.unwrap();
         publishers.insert(vss_path, publisher);
+
     }
     info!(
         "Subscribing to the following paths on the Kuksa Databroker: {:?}",
-        vss_paths
+        publishers.keys()
     );
 
     match kuksa_client.subscribe_target_values(provider_config.signals).await {

--- a/zenoh-kuksa-provider/src/provider_config.rs
+++ b/zenoh-kuksa-provider/src/provider_config.rs
@@ -11,18 +11,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::collections::HashSet;
-
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ProviderConfig {
     pub zenoh_config: zenoh::config::Config,
     pub kuksa: KuksaConfig,
-    pub signals: HashSet<String>,
+    pub signals: Vec<String>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct KuksaConfig {
     pub databroker_url: String,
 }

--- a/zenoh-kuksa-provider/src/utils/kuksa_utils.rs
+++ b/zenoh-kuksa-provider/src/utils/kuksa_utils.rs
@@ -11,8 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use kuksa::proto::v1::{datapoint::Value, DataType, Datapoint};
-use kuksa::Client;
+use kuksa_rust_sdk::kuksa::common::ClientTraitV1;
+use kuksa_rust_sdk::v1_proto::datapoint::Value;
+use kuksa_rust_sdk::v1_proto::{DataEntry, DataType, Datapoint};
+use kuksa_rust_sdk::kuksa::val::v1::KuksaClient;
 use log::warn;
 use prost_types::Timestamp;
 use std::collections::HashMap;
@@ -23,19 +25,20 @@ use zenoh::sample::Sample;
 use crate::utils::{metadata_store::MetadataInfo, zenoh_utils::zbytes_to_string};
 
 pub async fn fetch_metadata(
-    mut kuksa_client: Client,
-    paths: Vec<&str>,
+    mut kuksa_client: KuksaClient,
+    paths: Vec<String>,
     metadata_store: &super::metadata_store::MetadataStore,
-) -> Client {
+
+) -> KuksaClient {
     let mut store = metadata_store.lock().await;
 
-    let data_entries: Vec<kuksa::DataEntry> = kuksa_client.get_metadata(paths).await.unwrap();
+    let data_entries: Vec<DataEntry> = kuksa_client.get_metadata(paths).await.unwrap();
 
     for entry in data_entries {
         store.insert(
             entry.path,
             MetadataInfo {
-                data_type: DataType::from_i32(entry.metadata.unwrap().data_type)
+                data_type: DataType::try_from(entry.metadata.unwrap().data_type)
                     .unwrap_or(DataType::Unspecified),
             },
         );
@@ -99,22 +102,22 @@ pub fn datapoint_to_string(datapoint: &Datapoint) -> Option<String> {
         .value
         .as_ref()
         .map(|value| match value {
-            kuksa::proto::v1::datapoint::Value::String(v) => v.clone(),
-            kuksa::proto::v1::datapoint::Value::Bool(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::Int32(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::Int64(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::Uint32(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::Uint64(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::Float(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::Double(v) => v.to_string(),
-            kuksa::proto::v1::datapoint::Value::StringArray(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::BoolArray(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::Int32Array(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::Int64Array(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::Uint32Array(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::Uint64Array(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::FloatArray(v) => format!("{:?}", v.values),
-            kuksa::proto::v1::datapoint::Value::DoubleArray(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::String(v) => v.clone(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Bool(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Int32(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Int64(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Uint32(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Uint64(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Float(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Double(v) => v.to_string(),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::StringArray(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::BoolArray(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Int32Array(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Int64Array(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Uint32Array(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::Uint64Array(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::FloatArray(v) => format!("{:?}", v.values),
+            kuksa_rust_sdk::v1_proto::datapoint::Value::DoubleArray(v) => format!("{:?}", v.values),
         })
         .or_else(|| {
             warn!("Datapoint has no value");

--- a/zenoh-kuksa-provider/src/utils/metadata_store.rs
+++ b/zenoh-kuksa-provider/src/utils/metadata_store.rs
@@ -13,9 +13,8 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use kuksa_rust_sdk::v1_proto::DataType;
 use tokio::sync::Mutex;
-
-use kuksa::proto::v1::DataType;
 
 #[derive(Debug, Clone, Copy)]
 pub struct MetadataInfo {


### PR DESCRIPTION
The Zenoh Kuksa Provider now uses the newly published Kuksa Rust SDK.. 